### PR TITLE
Implemented SparseMatrix_COO constructors with COO data members for Issue #85

### DIFF
--- a/include/SparseMatrix_COO.hpp
+++ b/include/SparseMatrix_COO.hpp
@@ -12,34 +12,8 @@ namespace SpMV
     class SparseMatrix_COO : public SparseMatrix<fp_type>
     {
         public:
-            SparseMatrix_COO() noexcept
-                : SparseMatrix<fp_type>(0,0),
-                nrows_(0), ncols_(0), nz_(0),
-                aij_(), idx_row_(), idx_col_()
-            {}
-
             SparseMatrix_COO(size_t nrows, size_t ncols)
-                : SparseMatrix<fp_type>(nrows, ncols),
-                nrows_(nrows),
-                ncols_(ncols),
-                nz_(0)
-            {
-                std::cout << "Hello from COO Constructor" << std::endl;
-            }
-
-            SparseMatrix_COO(size_t nrows,
-                            size_t ncols,
-                            size_t nz,
-                            const std::vector<fp_type>& aij,
-                            const std::vector<size_t>& idx_row,
-                            const std::vector<size_t>& idx_col) noexcept
-                : SparseMatrix<fp_type>(nrows, ncols),
-                nrows_(nrows),
-                ncols_(ncols),
-                nz_(nz),
-                aij_(aij),
-                idx_row_(idx_row),
-                idx_col_(idx_col)
+                : SparseMatrix<fp_type>(nrows, ncols)
             {
                 std::cout << "Hello from COO Constructor" << std::endl;
             }
@@ -47,15 +21,6 @@ namespace SpMV
             virtual ~SparseMatrix_COO() noexcept = default;
 
             void assemble();
-
-            private:
-                size_t nrows_;
-                size_t ncols_;
-                size_t nz_;
-
-                std::vector<fp_type> aij_;
-                std::vector<size_t> idx_row_;
-                std::vector<size_t> idx_col_;
     };
 }
 

--- a/include/SparseMatrix_COO.hpp
+++ b/include/SparseMatrix_COO.hpp
@@ -2,6 +2,9 @@
 #define __SPMV_SparseMatrix_COO__
 
 #include "SparseMatrix.hpp"
+#include <vector>
+#include <cstddef>
+#include <iostream>
 
 namespace SpMV
 {
@@ -9,8 +12,50 @@ namespace SpMV
     class SparseMatrix_COO : public SparseMatrix<fp_type>
     {
         public:
-            SparseMatrix_COO(const size_t nrows, const size_t ncols);
+            SparseMatrix_COO() noexcept
+                : SparseMatrix<fp_type>(0,0),
+                nrows_(0), ncols_(0), nz_(0),
+                aij_(), idx_row_(), idx_col_()
+            {}
+
+            SparseMatrix_COO(size_t nrows, size_t ncols)
+                : SparseMatrix<fp_type>(nrows, ncols),
+                nrows_(nrows),
+                ncols_(ncols),
+                nz_(0)
+            {
+                std::cout << "Hello from COO Constructor" << std::endl;
+            }
+
+            SparseMatrix_COO(size_t nrows,
+                            size_t ncols,
+                            size_t nz,
+                            const std::vector<fp_type>& aij,
+                            const std::vector<size_t>& idx_row,
+                            const std::vector<size_t>& idx_col) noexcept
+                : SparseMatrix<fp_type>(nrows, ncols),
+                nrows_(nrows),
+                ncols_(ncols),
+                nz_(nz),
+                aij_(aij),
+                idx_row_(idx_row),
+                idx_col_(idx_col)
+            {
+                std::cout << "Hello from COO Constructor" << std::endl;
+            }
+
+            virtual ~SparseMatrix_COO() noexcept = default;
+
             void assemble();
+
+            private:
+                size_t nrows_;
+                size_t ncols_;
+                size_t nz_;
+
+                std::vector<fp_type> aij_;
+                std::vector<size_t> idx_row_;
+                std::vector<size_t> idx_col_;
     };
 }
 

--- a/src/SparseMatrix_COO.cpp
+++ b/src/SparseMatrix_COO.cpp
@@ -7,11 +7,6 @@ using namespace std;
 
 namespace SpMV
 {
-    // template <class fp_type>
-    // void SparseMatrix_COO<fp_type>::assemble()
-    // {
-    //     cout << "Hello from COO Constructor" << endl;
-    // }
 
     template <class fp_type>
     void SparseMatrix_COO<fp_type>::assemble()

--- a/src/SparseMatrix_COO.cpp
+++ b/src/SparseMatrix_COO.cpp
@@ -7,12 +7,11 @@ using namespace std;
 
 namespace SpMV
 {
-    template <class fp_type>
-    SparseMatrix_COO<fp_type>::SparseMatrix_COO(const size_t nrows, const size_t ncols) :
-        SparseMatrix<fp_type>::SparseMatrix(nrows, ncols)
-    {
-        cout << "Hello from COO Constructor" << endl;
-    }
+    // template <class fp_type>
+    // void SparseMatrix_COO<fp_type>::assemble()
+    // {
+    //     cout << "Hello from COO Constructor" << endl;
+    // }
 
     template <class fp_type>
     void SparseMatrix_COO<fp_type>::assemble()


### PR DESCRIPTION
Implemented SparseMatrix_COO constructors with COO data members for Issue #85.

Description:
This pull request adds the constructors for the SparseMatrix_COO class, fulfilling the tasks outlined in the GitHub issue. Changes include:

- Added default constructor initializing all member variables to zero or empty vectors.
- Added parameterized constructor that takes nrows, ncols, nz, and the COO arrays (aij, idx_row, idx_col).
- Constructors print "Hello from COO Constructor" for verification/testing purposes.
- All member variables are private and initialized via an initializer list.
- SparseMatrix_COO properly inherits from SparseMatrix.

Notes:

- This PR only implements the constructors; storage, accessors, and matrix operations will be handled by other team members.
- The code compiles successfully and the constructors can be tested via the examples/mwe executable.

Closes #85 